### PR TITLE
Update broken CiteProc link

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -105,7 +105,7 @@ title: Welcome to DataCite
           <div class="col-md-4 col-sm-4 svc-item">
             <div class="thumbnail">
               <div class="caption">
-                <% link_to 'http://crosscite.org/citeproc/' do %>
+                <% link_to 'https://crosscite.org/' do %>
                 <%= image_tag "home_citation.svg", :width => '200' %>
                 <% end %>
                 <p>


### PR DESCRIPTION
Returned `Cannot GET /citeproc/` and I guess they just moved the tool upwards to the main domain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/homepage/16)
<!-- Reviewable:end -->
