### PR TITLE
Changed to a new URL

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -105,7 +105,7 @@ title: Welcome to DataCite
           <div class="col-md-4 col-sm-4 svc-item">
             <div class="thumbnail">
               <div class="caption">
-                <% link_to 'https://crosscite.org/' do %>
+                <% link_to 'https://citation.crosscite.org/' do %>
                 <%= image_tag "home_citation.svg", :width => '200' %>
                 <% end %>
                 <p>


### PR DESCRIPTION
Because the current link to https://crosscite.org/ returns an uninformative "OK". Reported by @dphilip during a presentation about data citations [0].

0.https://zenodo.org/record/3648169

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/homepage/89)
<!-- Reviewable:end -->
