### PR TITLE
inintial service provider spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,6 @@
 # Ignore .DS_store file
 .DS_Store
 
-# ignore vendored assets and gems
-/vendor/node_modules
-/vendor/bundle
-
 .env
 
 .bundle
@@ -28,3 +24,5 @@
 .DS_Store
 .sass-cache
 build/
+node_modules
+.tmp/dist

--- a/source/javascripts/service_provider_container.js
+++ b/source/javascripts/service_provider_container.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const e = React.createElement;
+
+function ServiceProvider() {
+  const [error, setError] = React.useState(null);
+  const [isLoaded, setIsLoaded] = React.useState(false);
+  const [items, setItems] = React.useState([]);
+
+  function ApiError(props) {
+    this.status = props.status;
+    this.message = props.statusText
+    if (!this.message) {
+      if (this.status == 404) this.message = "Not found";
+    }
+  }
+
+  function ServiceProviderItem(props) {
+    return e('div', { key: props.id, className: 'row thumbnail svc-item' }, [
+      e('div', { className: 'col-md-4' },
+        props.logo ? e('img', { className: 'member-logo', src: 'https://strapi.stage.datacite.org' + props.logo }) : null ),
+      e('div', { className: 'col-md-8 stakeholderdescription' }, [
+        e('h3', null, props.name),
+        e('a', { href: props.website }, props.website),
+        e('div', { className: 'description' }, props.description)
+      ])
+    ])
+  }
+
+  React.useEffect(() => {
+    fetch("https://strapi.stage.datacite.org/service-providers")
+      .then((response) => {
+        if (!response.ok) throw new ApiError(response);
+        else return response.json();
+      })
+      .then(
+        (result) => {
+          setIsLoaded(true);
+          setItems(result);
+        },
+        (error) => {
+          setIsLoaded(true);
+          setError(error);
+        }
+      )
+  }, [])
+
+  if (error) {
+    return e(
+      'div', null, 'Error: ' + error.message
+    )
+  }
+
+  // loading should be fast, so no need to render before isLoaded
+
+  return e(
+    'div', null,
+    items.map(item =>
+      e(ServiceProviderItem, {
+        id: item.id,
+        name: item.Name,
+        logo: item.Logo ? item.Logo.url : null,
+        website: item.Website,
+        description: item.Description
+      })
+    )
+  )
+}
+
+const domContainer = document.querySelector('#service_provider_container');
+ReactDOM.render(e(ServiceProvider), domContainer);

--- a/source/layouts/service-provider.erb
+++ b/source/layouts/service-provider.erb
@@ -1,0 +1,26 @@
+<% wrap_layout :layout do %>
+  <header class="image-bg-fixed-height-small">
+    <div class="jumbotron">
+      <h1><%= current_page.data.title %></h1>
+    </div>
+  </header>
+
+  <section>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-9 section-content" id="content">
+          <%= yield %>
+        </div>
+        <div class="col-md-9 section-content" id="service_provider_container">
+      </div>
+    </div>
+  </section>
+
+  <!-- Load React. -->
+  <!-- Note: when deploying, replace "development.js" with "production.min.js". -->
+  <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>
+  
+  <!-- Load our React component. -->
+  <script src="javascripts/service_provider_container.js"></script>
+<% end %>

--- a/source/service-providers.html.md
+++ b/source/service-providers.html.md
@@ -1,0 +1,10 @@
+---
+title: Service Providers
+layout: service-provider
+---
+
+# What is a DataCite Service Provider?
+
+Text goes here.
+
+# DataCite Service Providers

--- a/source/stylesheets/homepage.css.scss
+++ b/source/stylesheets/homepage.css.scss
@@ -162,6 +162,10 @@ section h1 {
       font-weight: bold;
       margin-bottom: 0;
     }
+
+    .description {
+      margin-top: 10px;
+    }
   }
 }
 


### PR DESCRIPTION
## Purpose
Spike to evaluate a service provider implementation using Strapi as headless CMS and react to fetch and render the data.

## Approach
Setup Strapi as Docker container. Use Strapi REST API and React to fetch metadata and display on new **Service Provider** page.

## Questions
Does this implementation address the requirements, and enables a service provider listing with a reasonable effort? 

Consider turning this into JSX format once we have webpack configured.

## CMS Backend
<img width="807" alt="Bildschirmfoto 2020-06-13 um 22 11 14" src="https://user-images.githubusercontent.com/23151/84578150-d9597280-adc2-11ea-9d84-b89397fe5bde.png">

<img width="1338" alt="Bildschirmfoto 2020-06-13 um 22 08 10" src="https://user-images.githubusercontent.com/23151/84578101-7071fa80-adc2-11ea-8b91-a136bfd1ca9a.png">

## Homepage
<img width="909" alt="Bildschirmfoto 2020-06-13 um 22 06 37" src="https://user-images.githubusercontent.com/23151/84578077-30ab1300-adc2-11ea-86ce-992feddf1cdd.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/homepage/96)
<!-- Reviewable:end -->
