### PR TITLE
Styles for mobile cookie banner..

### DIFF
--- a/source/javascripts/consent.js
+++ b/source/javascripts/consent.js
@@ -24,8 +24,9 @@ function Consent() {
       domain = '.stage.datacite.org';
   }
 
-  const cookieStyle = { fontSize: '16px', height: '90px' }
+  const cookieStyle = { fontSize: '16px', height: '95px', flexWrap: 'nowrap !important' }
   const linkStyle = { color: '#fecd23' }
+  const myContentStyle = {}
 
   return (
     <CookieConsent
@@ -38,6 +39,11 @@ function Consent() {
       extraCookieOptions={{ domain: domain }}
       overlay={true}
       enableDeclineButton
+      buttonWrapperClasses="MY_BUTTON_WRAPPER_CLASS"
+      containerClasses="CookieConsent MY_CONTAINER_CLASS"
+      contentClasses="MY_CONTENT_CLASS"
+      contentStyle={myContentStyle}
+      declineButtonClasses="MY_DECLINE_BUTTON_CLASS"
     >
       We use cookies on our website. Some are technically necessary, others help
       us improve your user experience. You can decline non-essential cookies by

--- a/source/stylesheets/homepage.scss
+++ b/source/stylesheets/homepage.scss
@@ -532,3 +532,42 @@ ul.contact {
 .consent-cookie a {
   color: #FECD23 !important;
 }
+
+/* New styles for mobile-friendly cookie bar. */
+
+.MY_BUTTON_WRAPPER_CLASS {
+  white-space: nowrap;
+}
+
+@media screen and (min-width: 376px) {
+  .MY_CONTENT_CLASS {
+    flex: 1 0 180px !important;
+  }
+}
+
+@media screen and (max-width: 375px) {
+  .MY_CONTAINER_CLASS {
+    height: 130px !important;
+  }
+
+  .MY_CONTENT_CLASS {
+    flex: 1 0 160px !important;
+		font-size: 12px;
+    position: relative;
+    top: -25px;
+  }
+
+  .MY_DECLINE_BUTTON_CLASS {
+    margin: 15px 5px !important
+  }
+
+  .MY_BUTTON_WRAPPER_CLASS {
+    white-space: nowrap;
+    position: relative;
+    top: 5px;
+  }
+
+  .MY_BUTTON_WRAPPER_CLASS button {
+    height: 50px;
+  }
+}


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Related to datacite/datacite#1151.   Makes the accept/reject cookie buttons available on mobile devices down to 360px wide screens.

## Approach
<!--- _How does this change address the problem?_ -->

Added new css for mobile sized screens. Set parameters appropriately for react-cookie-consent package which controls the cookie consent bar.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

Testing for different screen sizes by someone other than myself.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/homepage/123)
<!-- Reviewable:end -->
