### PR TITLE
Issue datacite/datacite#1215 - Consent cookie banner blocks access to…

### DIFF
--- a/source/javascripts/consent.js
+++ b/source/javascripts/consent.js
@@ -42,7 +42,7 @@ function Consent() {
       sameSite="strict"
       cookieName="_consent"
       extraCookieOptions={{ domain: domain }}
-      overlay={true}
+      overlay={false}
       enableDeclineButton
       buttonWrapperClasses="MY_BUTTON_WRAPPER_CLASS"
       containerClasses="CookieConsent MY_CONTAINER_CLASS"


### PR DESCRIPTION
Should cover:

- Homepage
- Blog
- Search
- Schema
- Fabrica

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Make the  consent cookie modal to allow users with pop-up blockers access to pages.

closes: datacite/datacite#1215

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->
https://www.npmjs.com/package/react-cookie-consent#projects-using-react-cookie-consent 

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacite/homepage/128)
<!-- Reviewable:end -->
