### PR TITLE
update Americas expert group list

### DIFF
--- a/source/steering.html.erb
+++ b/source/steering.html.erb
@@ -1,5 +1,5 @@
 ---
-title: DataCite <li>Steering groups
+title: DataCite Steering groups
 ---
 
 <header class="image-bg-fixed-height-small">
@@ -98,7 +98,9 @@ title: DataCite <li>Steering groups
 	</ul>
 	<h2>Current Americas Expert Group Members:</h2>
 	<ul>
-		<li>Rebecca Ross, CRKN (Co-Chair)</li>
+		<li>John Aspler, CRKN</li>
+		<li>Cameron Cook, University of Wisconsin-Madison</li>
+		<li>Lisa Johnston, University of Minnesota</li>
 		<li>Liz Krznarich, DataCite</li>
 		<li>Maria Lucia Lizarazo, Universidad del Rosario</li>
 		<li>Sheila Rabun, LYRASIS</li>


### PR DESCRIPTION
## Purpose
Add new members to Americas expert group list and remove those no longer involved.
