### PR TITLE
remove latest news section and add text link to blog

### DIFF
--- a/source/includes/_header.html.erb
+++ b/source/includes/_header.html.erb
@@ -66,13 +66,12 @@
         <li class="active"><%= link_to 'Become a member', '/become.html' %><span class="sr-only">(current)</span></a></li>
 
         <li>
+          <%= link_to 'Blog', 'https://blog.datacite.org' %>
+        </li>
+
+        <li>
           <% link_to '/contact.html' do %>
             <i class="fas fa-envelope fa-lg"></i>
-          <% end %>
-        </li>
-        <li>
-          <% link_to 'https://blog.datacite.org' do %>
-            <i class="fas fa-blog fa-lg"></i>
           <% end %>
         </li>
         <li>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -117,19 +117,3 @@ title: Welcome to DataCite
     </div>
   </div>
 </section>
-
-<section>
-  <div class="container-fluid">
-    <div class="row">
-      <div class="col-md-12">
-        <h1 class="svc-heading">Latest news</h1>
-      </div>
-      <div class="container">
-        <div class="row">
-          <div id="bloglist"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-<script src="javascripts/blog.js"></script>


### PR DESCRIPTION
## Purpose
Removing "Latest news" section from homepage because it has not worked since July  2021.
closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
